### PR TITLE
Bug in cookieString function

### DIFF
--- a/cookies.js
+++ b/cookies.js
@@ -59,7 +59,8 @@ exports.readBrowserCookie = function (name) {
 exports.cookieString = function (req, opt) {
     var str = escape(opt.name) + '=' + escape(opt.value) + '; path=' + opt.path;
     if (opt.days) {
-        var expires = new Date().setTime(
+        var expires = new Date();
+        expires.setTime(
             new Date().getTime() + 1000 * 60 * 60 * 24 * opt.days
         );
         str += '; expires=' + expires.toGMTString();


### PR DESCRIPTION
In both firefox and chrome, the Date::setTime returns the value passed to the function causing 'expires' to be an integer instead of an instance of the Date object.

This resolves that issue.
